### PR TITLE
Fixes existing performer to find by IG id instead of full token

### DIFF
--- a/app/controllers/api/v1/performers_controller.rb
+++ b/app/controllers/api/v1/performers_controller.rb
@@ -18,7 +18,7 @@ class Api::V1::PerformersController < ApplicationController
       if performer.save
         render json: performer
       else
-        performer = Performer.find_by(instagram_token: params[:performer][:instagram_token])
+        performer = Performer.find_by(instagram_token: params[:performer][:instagram_token].split('.')[0])
         render json: performer
       end
     end

--- a/spec/requests/performer_spec.rb
+++ b/spec/requests/performer_spec.rb
@@ -30,11 +30,36 @@ describe "Performers API" do
   it 'can delete a performer' do
     performer1 = Performer.create(name: "Vivacious", bio: "Best queen in town!", instagram_token: "15940466.b3445ea.f5eaa7f9acf243d7bb658a6ca057d0db", insta_url: "https://www.instagram.com/naomismalls/", facebook_url: "www.facebook.com", twitter_url: "www.twitter.com")
     performer2 = Performer.create(name: "Bootylicious", bio: "Best queen in town!", instagram_token: "15940466.b3445ea.f5eaa7f9acf243d7bb658a6ca057dude", insta_url: "https://www.instagram.com/naomismalls/", facebook_url: "www.facebook.com", twitter_url: "www.twitter.com")
-    
+
     delete "/api/v1/performers/#{performer1.id}"
 
     expect(response).to be_successful
     expect(Performer.all.count).to eq(1)
+  end
+
+  it 'can create a performer by instagram token' do
+    body = {performer: {
+      instagram_token: "15940466.b3445ea.b3e1d1e5e3fa4c76968cfcf6cdb3a6c3"
+    }}
+    post "/api/v1/performers/", params: body
+
+    expect(response).to be_successful
+    performer = JSON.parse(response.body)
+    expect(performer["instagram_token"]).to eq("15940466")
+  end
+
+  it 'can return a performer by instagram token' do
+    performer1 = Performer.create(name: "Vivacious", bio: "Best queen in town!", instagram_token: "15940466", insta_url: "https://www.instagram.com/naomismalls/", facebook_url: "www.facebook.com", twitter_url: "www.twitter.com")
+
+    body = {performer: {
+      instagram_token: "15940466.b3445ea.b3e1d1e5e3fa4c76968cfcf6cdb3a6c3"
+    }}
+    post "/api/v1/performers/", params: body
+
+    expect(response).to be_successful
+    performer = JSON.parse(response.body)
+    expect(performer["instagram_token"]).to eq("15940466")
+    expect(performer["name"]).to eq("Vivacious")
   end
 
 end


### PR DESCRIPTION
Closes #57 

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes POST /performers for an existing performer. We updated the performer creation to store instagram ID only instead of the full JSON web token (as it was resulting in duplicate performer creation). We missed updating this for an existing performer, so when an existing performer OAuth's on the frontend, it was returning a null user. This has been updated within this PR.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other, Please explain:
`Your message here`

## Has This Been Tested?
- [ ] No
- [x] Yes
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration:

Adds test to post a new performer by instagram_token, and to post an existing performer by instagram_token

# Checklist:

- [x] My code has no unused/commented out code
- [x] My code has no console logs
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
